### PR TITLE
Custom Toolbar Settings with reflection

### DIFF
--- a/Editor/CustomToolbar/Scripts/Setting/CustomToolbarReordableList.cs
+++ b/Editor/CustomToolbar/Scripts/Setting/CustomToolbarReordableList.cs
@@ -2,6 +2,9 @@
 using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;
+using System;
+using System.Reflection;
+using System.Linq;
 
 internal static class CustomToolbarReordableList {
 	internal static ReorderableList Create(List<BaseToolbarElement> configsList, GenericMenu.MenuFunction2 menuItemHandler) {
@@ -13,42 +16,21 @@ internal static class CustomToolbarReordableList {
 		};
 
 		reorderableList.onAddDropdownCallback = (buttonRect, list) => {
-			//TODO: add items without changing this file
-			// Probably reflection can helps
-			BaseToolbarElement[] elements = new BaseToolbarElement[] {
-				new ToolbarSides(),
-				new ToolbarSpace(),
-				null,
 
-				new ToolbarTimeslider(),
-				new ToolbarFPSSlider(),
-				null,
-
-				new ToolbarSceneSelection(),
-				new ToolbarEnterPlayMode(),
-				null,
-
-				new ToolbarReloadScene(),
-				new ToolbarStartFromFirstScene(),
-				null,
-
-				new ToolbarSavingPrefs(),
-				new ToolbarClearPrefs(),
-				null,
-
-				new ToolbarRecompile(),
-				new ToolbarReserializeSelected(),
-				new ToolbarReserializeAll(),
-				null,
-			};
+			BaseToolbarElement[] elements = GetNewObjectsOfType<BaseToolbarElement>().ToArray();
 
 			GenericMenu menu = new GenericMenu();
 
-			foreach (var element in elements) {
-				if(element == null) 
-					menu.AddSeparator("");
-				else 
-					menu.AddItem(new GUIContent(element.NameInList), false, menuItemHandler, element);
+            int lastSortingGroup = 0;
+			foreach (var element in elements)
+			{
+                if (lastSortingGroup != element.SortingGroup)
+                {
+                    menu.AddSeparator("");
+                    lastSortingGroup = element.SortingGroup;
+                }
+                
+		        menu.AddItem(new GUIContent(element.NameInList), false, menuItemHandler, element);
 			}
 
 			menu.ShowAsContext();
@@ -56,4 +38,103 @@ internal static class CustomToolbarReordableList {
 
 		return reorderableList;
 	}
+
+    //  Get the possible menu options. Generates the cache if it needs to
+    private static List<T> GetNewObjectsOfType<T>() where T : class, IComparable<T>
+    {
+        if (toolbarOptions == null)
+        {
+            toolbarOptions = FindConstructors<T>();
+        }
+
+        List<T> objects = new List<T>();
+
+        //  Create each object using the data from the cache
+        foreach (ConstructorOption item in toolbarOptions)
+        {
+            objects.Add((T)item.constructor.Invoke(item.parameters));
+        }
+
+        objects.Sort();
+
+        return objects;
+    }
+
+    //  Finds all the toolbar elements, and caches their constructors and parameters
+    private static ConstructorOption[] FindConstructors<T>() where T : class, IComparable<T>
+    {
+        List<ConstructorOption> typeConstructorList = new List<ConstructorOption>();
+
+        //  Loop over every type in the assembly
+        foreach (Type type in
+            Assembly.GetAssembly(typeof(T)).GetTypes()
+            .Where(myType => myType.IsClass && !myType.IsAbstract && myType.IsSubclassOf(typeof(T))))
+        {
+            //  Get the default constructor
+            ConstructorInfo constructor = type.GetConstructor(Type.EmptyTypes);
+            object[] constructorParameters = null;
+
+            //  If we cant find a default constructor, get all the constructors, and try to find an alternative
+            if (constructor == null)
+            {
+                ConstructorInfo[] constructors = type.GetConstructors();
+
+                foreach (var item in constructors)
+                {
+                    //  Find a constructor that has all optional parameters, then use the default parameter values
+                    ParameterInfo[] parameters = item.GetParameters();
+                    object[] tempParameters = new object[parameters.Length];
+
+                    int validParameters = 0;
+
+                    for (int i = 0; i < parameters.Length; i++)
+                    {
+                        ParameterInfo parameter = parameters[i];
+                        object defaultValue = parameter.RawDefaultValue;
+
+                        //  This is to check that it actually has a default parameter value
+                        if (defaultValue != DBNull.Value)
+                        {
+                            validParameters++;
+                            tempParameters[i] = defaultValue;
+                        }
+                    }
+
+                    if (validParameters == parameters.Length)
+                    {
+                        constructor = item;
+                        constructorParameters = tempParameters;
+                    }
+                }
+            }
+
+            //  If we have found a suitable constructor, then add it to the list of possible types 
+            if (constructor != null)
+            {
+                typeConstructorList.Add(new ConstructorOption(constructor, constructorParameters));
+            }
+            else
+            {
+                Debug.LogWarning("Custom Toolbar was unable to find a suitable constructor for the class " + type.ToString() +
+                    ". To show up in the Project Settings it must either contain a default constructor (no parameters), or a constructor where all parameters have a default value.");
+            }
+        }
+
+        return typeConstructorList.ToArray();
+    }
+
+    //  This is to cache the possible toolbar options
+    private static ConstructorOption[] toolbarOptions = null;
+
+    private struct ConstructorOption
+    {
+        public ConstructorInfo constructor;
+        public object[] parameters;
+
+        public ConstructorOption(ConstructorInfo constructor, object[] parameters)
+        {
+            this.constructor = constructor;
+            this.parameters = parameters;
+        }
+    }
 }

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/BaseToolbarElement.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/BaseToolbarElement.cs
@@ -6,7 +6,7 @@ using UnityToolbarExtender;
 using UnityEditor;
 
 [Serializable]
-abstract internal class BaseToolbarElement {
+abstract internal class BaseToolbarElement : IComparable<BaseToolbarElement> {
 	static protected string GetPackageRootPath {
 		get {
 			return "Packages/com.smkplus.custom-toolbar";
@@ -14,6 +14,7 @@ abstract internal class BaseToolbarElement {
 	}
 
 	abstract public string NameInList { get; }
+	virtual public int SortingGroup { get; }
 
 	[SerializeField] protected bool IsEnabled = true;
 	[SerializeField] protected float WidthInToolbar;
@@ -66,4 +67,9 @@ abstract internal class BaseToolbarElement {
 
 	abstract protected void OnDrawInList(Rect position);
 	abstract protected void OnDrawInToolbar();
+
+    public int CompareTo(BaseToolbarElement other)
+    {
+		return SortingGroup.CompareTo(other.SortingGroup);
+    }
 }

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarClearPrefs.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarClearPrefs.cs
@@ -10,6 +10,7 @@ internal class ToolbarClearPrefs : BaseToolbarElement {
 	private static GUIContent clearPlayerPrefsBtn;
 
 	public override string NameInList => "[Button] Clear prefs";
+	public override int SortingGroup => 4;
 
 	public override void Init() {
 		clearPlayerPrefsBtn = EditorGUIUtility.IconContent("SaveFromPlay");

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarEnterPlayMode.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarEnterPlayMode.cs
@@ -12,6 +12,7 @@ internal class ToolbarEnterPlayMode : BaseToolbarElement {
 #endif
 
 	public override string NameInList => "[Dropdown] Enter play mode option";
+	public override int SortingGroup => 2;
 
 	public override void Init() {
 		enterPlayModeOption = new[]{

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarFPSSlider.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarFPSSlider.cs
@@ -12,6 +12,7 @@ internal class ToolbarFPSSlider : BaseToolbarElement {
 	int selectedFramerate;
 
 	public override string NameInList => "[Slider] FPS";
+	public override int SortingGroup => 1;
 
 	public override void Init() {
 		selectedFramerate = 60;

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarRecompile.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarRecompile.cs
@@ -9,6 +9,7 @@ internal class ToolbarRecompile : BaseToolbarElement {
 	private static GUIContent recompileBtn;
 
 	public override string NameInList => "[Button] Recompile";
+	public override int SortingGroup => 5;
 
 	public override void Init() {
 		recompileBtn = EditorGUIUtility.IconContent("WaitSpin05");

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarReloadScene.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarReloadScene.cs
@@ -12,6 +12,7 @@ internal class ToolbarReloadScene : BaseToolbarElement {
 	private static GUIContent reloadSceneBtn;
 
 	public override string NameInList => "[Button] Reload scene";
+	public override int SortingGroup => 3;
 
 	public override void Init() {
 		reloadSceneBtn = new GUIContent((Texture2D)AssetDatabase.LoadAssetAtPath($"{GetPackageRootPath}/Editor/CustomToolbar/Icons/LookDevResetEnv@2x.png", typeof(Texture2D)), "Reload scene");

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarReserializeAll.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarReserializeAll.cs
@@ -9,6 +9,7 @@ internal class ToolbarReserializeAll : BaseToolbarElement {
 	private static GUIContent reserializeAllBtn;
 
 	public override string NameInList => "[Button] Reserialize all";
+	public override int SortingGroup => 5;
 
 	public override void Init() {
 		reserializeAllBtn = EditorGUIUtility.IconContent("P4_Updating");

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarReserializeSelected.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarReserializeSelected.cs
@@ -9,6 +9,7 @@ internal class ToolbarReserializeSelected : BaseToolbarElement {
 	private static GUIContent reserializeSelectedBtn;
 
 	public override string NameInList => "[Button] Reserialize selected";
+	public override int SortingGroup => 5;
 
 	public override void Init() {
 		reserializeSelectedBtn = EditorGUIUtility.IconContent("Refresh");

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarSavingPrefs.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarSavingPrefs.cs
@@ -12,6 +12,7 @@ internal class ToolbarSavingPrefs : BaseToolbarElement {
 	private static bool _deleteKeys = false;
 
 	public override string NameInList => "[Button]Disable saving prefs";
+	public override int SortingGroup => 4;
 
 	public override void Init() {
 		_deleteKeys = false;

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarSceneSelection.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarSceneSelection.cs
@@ -11,6 +11,7 @@ using UnityEditor.SceneManagement;
 [Serializable]
 internal class ToolbarSceneSelection : BaseToolbarElement {
 	public override string NameInList => "[Dropdown] Scene selection";
+	public override int SortingGroup => 2;
 
 	[SerializeField] bool showSceneFolder = true;
 

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarStartFromFirstScene.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarStartFromFirstScene.cs
@@ -12,6 +12,7 @@ internal class ToolbarStartFromFirstScene : BaseToolbarElement {
 	private static GUIContent startFromFirstSceneBtn;
 
 	public override string NameInList => "[Button] Start from first scene";
+	public override int SortingGroup => 3;
 
 	public override void Init() {
 		EditorApplication.playModeStateChanged += LogPlayModeState;

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarTimeslider.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarTimeslider.cs
@@ -10,6 +10,7 @@ internal class ToolbarTimeslider : BaseToolbarElement {
 	[SerializeField] float maxTime = 120;
 
 	public override string NameInList => "[Slider] Timescale";
+	public override int SortingGroup => 1;
 
 	public override void Init() {
 


### PR DESCRIPTION
I resolved a TODO that I found on line 16 of CustomToolbarReordableList.cs. I added reflection to find all the classes in the namespace which inherit from BaseToolbarElement. Reflection is then used to call their constructors so that the selection menu for which toolbar element is being added can be populated.