### PR TITLE
CustomToolbarSetting.asset moved under UserSettings

### DIFF
--- a/Editor/CustomToolbar/Scripts/Setting/CustomToolbarSetting.cs
+++ b/Editor/CustomToolbar/Scripts/Setting/CustomToolbarSetting.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace UnityToolbarExtender
 {
 #if UNITY_2020_3_OR_NEWER
-    [FilePath("ProjectSettings/CustomToolbarSetting.asset", FilePathAttribute.Location.ProjectFolder)]
+    [FilePath("UserSettings/CustomToolbarSetting.asset", FilePathAttribute.Location.ProjectFolder)]
     internal class CustomToolbarSetting : ScriptableSingleton<CustomToolbarSetting> {
         [SerializeReference] List<BaseToolbarElement> _elements = new() {
             new ToolbarEnterPlayMode(),

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarStartFromFirstScene.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarStartFromFirstScene.cs
@@ -26,20 +26,27 @@ internal class ToolbarStartFromFirstScene : BaseToolbarElement {
 	protected override void OnDrawInToolbar() {
 		if (GUILayout.Button(startFromFirstSceneBtn, ToolbarStyles.commandButtonStyle)) {
 			if (!EditorApplication.isPlaying) {
-				EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo();
-				EditorPrefs.SetInt("LastActiveSceneToolbar", EditorSceneManager.GetActiveScene().buildIndex);
+				if(!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+				{
+					EditorApplication.isPlaying = false;
+					return;
+				}
+				SessionState.SetString(LastActiveSceneToolbar, EditorSceneManager.GetActiveScene().path);
 				EditorSceneManager.OpenScene(SceneUtility.GetScenePathByBuildIndex(0));
 			}
 
 			EditorApplication.isPlaying = !EditorApplication.isPlaying;
 		}
 	}
-
-	private static void LogPlayModeState(PlayModeStateChange state) {
-		if (state == PlayModeStateChange.EnteredEditMode && EditorPrefs.HasKey("LastActiveSceneToolbar")) {
-			EditorSceneManager.OpenScene(
-				SceneUtility.GetScenePathByBuildIndex(EditorPrefs.GetInt("LastActiveSceneToolbar")));
-			EditorPrefs.DeleteKey("LastActiveSceneToolbar");
+	
+	private const string LastActiveSceneToolbar = "LastActiveSceneToolbar";
+	private static void LogPlayModeState(PlayModeStateChange state)
+	{
+		if (state == PlayModeStateChange.EnteredEditMode)
+		{
+			if(string.IsNullOrWhiteSpace(SessionState.GetString(LastActiveSceneToolbar,string.Empty))) return;
+			EditorSceneManager.OpenScene(SessionState.GetString(LastActiveSceneToolbar,string.Empty));
+			SessionState.EraseString(LastActiveSceneToolbar);
 		}
 	}
 }


### PR DESCRIPTION
Would be better if settings ignored under UserSettings, different users can change their settings independently.