### PR TITLE
Consistent Behavior for FPS and Time Slider

### DIFF
--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarFPSSlider.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarFPSSlider.cs
@@ -15,8 +15,9 @@ internal class ToolbarFPSSlider : BaseToolbarElement {
 	public override int SortingGroup => 1;
 
 	public override void Init() {
-		selectedFramerate = 60;
-	}
+		if (selectedFramerate == 0)
+			selectedFramerate = 60;
+    }
 
 	public ToolbarFPSSlider(int minFPS = 1, int maxFPS = 120) : base(200) {
 		this.minFPS = minFPS;

--- a/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarTimeslider.cs
+++ b/Editor/CustomToolbar/Scripts/ToolbarElements/ToolbarTimeslider.cs
@@ -9,14 +9,21 @@ internal class ToolbarTimeslider : BaseToolbarElement {
 	[SerializeField] float minTime = 1;
 	[SerializeField] float maxTime = 120;
 
-	public override string NameInList => "[Slider] Timescale";
+    bool defaultSetOnce;
+    float selectedTimeScale;
+
+    public override string NameInList => "[Slider] Timescale";
 	public override int SortingGroup => 1;
 
 	public override void Init() {
+		if (!defaultSetOnce)
+		{
+			defaultSetOnce = true;
+			selectedTimeScale = 1;
+        }
+    }
 
-	}
-
-	public ToolbarTimeslider(float minTime = 0.0f, float maxTime = 10.0f) : base(200) {
+	public ToolbarTimeslider(float minTime = 0f, float maxTime = 10.0f) : base(200) {
 		this.minTime = minTime;
 		this.maxTime = maxTime;
 	}
@@ -40,6 +47,8 @@ internal class ToolbarTimeslider : BaseToolbarElement {
 
 	protected override void OnDrawInToolbar() {
 		EditorGUILayout.LabelField("Time", GUILayout.Width(30));
-		Time.timeScale = EditorGUILayout.Slider("", Time.timeScale, minTime, maxTime, GUILayout.Width(WidthInToolbar - 30.0f));
-	}
+        selectedTimeScale = EditorGUILayout.Slider("", selectedTimeScale, minTime, maxTime, GUILayout.Width(WidthInToolbar - 30.0f));
+        if (EditorApplication.isPlaying && selectedTimeScale != Time.timeScale)
+            Time.timeScale = selectedTimeScale;
+    }
 }


### PR DESCRIPTION
Before these changes, Time Slider would maintain the value sometimes in and out of playmode while fps slider wont which caused a bit of confusion now and then.
The Sliders was also resetting back to the default value each time you get in to playmode when you want to go into playmode with set Time or FPS and was annoying and confusing when it resets.

This PR makes them have consistent behavior by
- Setting the default value only once during opening of the project.
- Time Slider having the same Check as the FPS Slider before appling the new value.
- The new check prevents the unnesscary file changes of the Timescale value in the project setting causing it to come up as changes when committing.